### PR TITLE
Added property to toggle animation when text field becomes first responder

### DIFF
--- a/UIFloatLabelTextField/UIFloatLabelTextField.h
+++ b/UIFloatLabelTextField/UIFloatLabelTextField.h
@@ -120,6 +120,13 @@ typedef NS_ENUM(NSUInteger, UIFloatLabelAnimationType)
 @property (nonatomic, assign) NSNumber *selectAllEnabled UI_APPEARANCE_SELECTOR;
 
 /**
+ * Enable the float label animation when becoming first responder
+ *
+ * Defaults to NO.
+ */
+@property (nonatomic, assign) NSNumber *toggleOnFirstResponder UI_APPEARANCE_SELECTOR;
+
+/**
  Toggles the float label using an animation
  @param animationType The desired animation (and final state) for the float label.
  */

--- a/UIFloatLabelTextField/UIFloatLabelTextField.m
+++ b/UIFloatLabelTextField/UIFloatLabelTextField.m
@@ -137,6 +137,8 @@
     // animationDuration
     _floatLabelShowAnimationDuration = @0.25f;
     _floatLabelHideAnimationDuration = @0.05f;
+    
+    _toggleOnFirstResponder = @NO;
 }
 
 - (void)setupMenuController
@@ -345,6 +347,9 @@
     _floatLabel.textColor = _floatLabelActiveColor;
     _storedText = [self text];
     
+    if ([_toggleOnFirstResponder isEqual:@YES])
+        [self toggleFloatLabel:UIFloatLabelAnimationTypeShow];
+    
     return YES;
 }
 
@@ -355,6 +360,9 @@
     }
     
     [super resignFirstResponder];
+    
+    if ([_toggleOnFirstResponder isEqual:@YES])
+        [self toggleFloatLabel:UIFloatLabelAnimationTypeHide];
     
     return YES;
 }


### PR DESCRIPTION
I've added a property to set up the float label to animate when the text field becomes the first responder.

The property is `toggleOnFirstResponder`.

It probably lacks some polishing. Any advise are welcome.