### PR TITLE
Text field should not be cleared if delegate selector returns NO

### DIFF
--- a/UIFloatLabelTextField/UIFloatLabelTextField.m
+++ b/UIFloatLabelTextField/UIFloatLabelTextField.m
@@ -227,7 +227,10 @@
 {
     // Call UITextFieldDelegate's 'textFieldShouldClear' method if delegate is set
     if ([self.delegate respondsToSelector:@selector(textFieldShouldClear:)]) {
-        [self.delegate textFieldShouldClear:self];
+        BOOL shouldClear = [self.delegate textFieldShouldClear:self];
+        if (!shouldClear) {
+            return;
+        }
     }
     
     // Create array, where each index contains one character from textField


### PR DESCRIPTION
In the function -clearTextField in the UIFloatLabelTextField class the text field is cleared when the clear button is pressed. However, if the UITextFieldDelegate selector -textFieldShouldClear:, which is called within -clearTextField, returns NO the text field is cleared anyway which is not the expected behavior. This commit checks what -textFieldShouldClear: returns and continues to clear the text field only if it returns YES.